### PR TITLE
Replace deprecated MAINTAINER command

### DIFF
--- a/32bit-with-astropy/Dockerfile
+++ b/32bit-with-astropy/Dockerfile
@@ -3,7 +3,7 @@
 # on top of the existing astropy-32bit-test-env Docker image.
 
 FROM astropy/astropy-32bit-test-env:1.6
-MAINTAINER Thomas P. Robitaille <thomas.robitaille@gmail.com>
+LABEL authors="Thomas Robitaille <thomas.robitaille@gmail.com>, Larry Bradley <larry.bradley@gmail.com>"
 
 RUN easy_install pip
 RUN pip install astropy

--- a/32bit/Dockerfile
+++ b/32bit/Dockerfile
@@ -2,7 +2,7 @@
 # run 32-bit tests for Astropy
 
 FROM ubuntu:14.04
-MAINTAINER Thomas P. Robitaille <thomas.robitaille@gmail.com>
+LABEL authors="Thomas Robitaille <thomas.robitaille@gmail.com>, Larry Bradley <larry.bradley@gmail.com>"
 
 RUN dpkg --add-architecture i386
 RUN apt-get update


### PR DESCRIPTION
This PR replaces the deprecated MAINTAINER (https://docs.docker.com/engine/reference/builder/#maintainer-deprecated) with LABEL.